### PR TITLE
ci: enable asan and tsan

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,7 +127,7 @@ task:
 
 task:
   name: '[depends, sanitizers: thread (TSan), no gui] [hirsute]'
-  only_if: false
+  only_if: true
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:hirsute
@@ -150,7 +150,7 @@ task:
 
 task:
   name: '[no depends, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer] [hirsute]'
-  only_if: false
+  only_if: true
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:hirsute

--- a/src/metrics/tx.cpp
+++ b/src/metrics/tx.cpp
@@ -1,4 +1,5 @@
 #include <metrics/metrics.h>
+#include <algorithm>
 
 namespace metrics {
 std::unique_ptr<TxMetrics> TxMetrics::make(const std::string& chain, prometheus::Registry& registry, bool noop)
@@ -35,10 +36,12 @@ TxMetricsImpl::TxMetricsImpl(const std::string& chain, prometheus::Registry& reg
         "coinbase", "not-standard", "tx-size-small", "non-final", "txn-already-in-mempool", "txn-same-nonwitness-data-in-mempool",
         "bip125-replacement-disallowed", "txn-mempool-conflict", "txn-already-known", "bad-txns-inputs-missingorspent",
         "non-BIP68-final", "bad-txns-nonstandard-inputs", "bad-witness-nonstandard", "bad-txns-too-many-sigops",
-        "too-long-mempool-chain", "bad-txns-spends-conflicting-tx", "insufficient-fee", "too-many-potential-replacements",
+        "too-long-mempool-chain", "bad-txns-spends-conflicting-tx", "insufficient fee", "too many potential replacements",
         "replacement-adds-unconfirmed", "unknown"};
     for (const auto& item : reasons) {
-        _single_transaction_counter.insert({item, &single_transaction_family.Add({{"result", "rejected"}, {"reason", item}})});
+         std::string lbl = item;
+         std::replace(lbl.begin(), lbl.end(), ' ', '-');
+        _single_transaction_counter.insert({item, &single_transaction_family.Add({{"result", "rejected"}, {"reason", lbl}})});
     }
     _cache_gauge = &FamilyGauge("tx_cache").Add({});
     /*

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -834,7 +834,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             CFeeRate oldFeeRate(mi->GetModifiedFee(), mi->GetTxSize());
             if (newFeeRate <= oldFeeRate)
             {
-                return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient-fee",
+                return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee",
                                      strprintf("rejecting replacement %s; new feerate %s <= old feerate %s",
                                                hash.ToString(),
                                                newFeeRate.ToString(),
@@ -862,7 +862,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 nConflictingSize += it->GetTxSize();
             }
         } else {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-many-potential-replacements",
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too many potential replacements",
                                  strprintf("rejecting replacement %s; too many potential replacements (%d > %d)\n",
                                            hash.ToString(),
                                            nConflictingCount,
@@ -898,7 +898,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // transactions would not be paid for.
         if (nModifiedFees < nConflictingFees)
         {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient-fee",
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee",
                                  strprintf("rejecting replacement %s, less fees than conflicting txs; %s < %s",
                                            hash.ToString(), FormatMoney(nModifiedFees), FormatMoney(nConflictingFees)));
         }
@@ -908,7 +908,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         CAmount nDeltaFees = nModifiedFees - nConflictingFees;
         if (nDeltaFees < ::incrementalRelayFee.GetFee(nSize))
         {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient-fee",
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee",
                                  strprintf("rejecting replacement %s, not enough additional fees to relay; %s < %s",
                                            hash.ToString(),
                                            FormatMoney(nDeltaFees),


### PR DESCRIPTION
Restore error messages for invalid transactions to tag v22.0.
This is so tests can pass