### PR TITLE
metrics: Rename label for block_connect 'connect-total' 

### DIFF
--- a/src/metrics/block.cpp
+++ b/src/metrics/block.cpp
@@ -108,9 +108,9 @@ void BlockMetricsImpl::ConnectLoadBlockDisk(int64_t current, double avg)
 {
     this->setConnect("load", current, avg);
 }
-void BlockMetricsImpl::ConnectBlockTotal(int64_t current, double avg)
+void BlockMetricsImpl::ConnectBlock(int64_t current, double avg)
 {
-    this->setConnect("connect-total", current, avg);
+    this->setConnect("connect", current, avg);
 }
 void BlockMetricsImpl::ConnectFlushView(int64_t current, double avg)
 {
@@ -120,7 +120,7 @@ void BlockMetricsImpl::ConnectFlushDisk(int64_t current, double avg)
 {
     this->setConnect("flush-disk", current, avg);
 }
-void BlockMetricsImpl::ConnectUpdate(int64_t current, double avg)
+void BlockMetricsImpl::ConnectUpdateTip(int64_t current, double avg)
 {
     this->setConnect("update-tip", current, avg);
 }
@@ -131,5 +131,9 @@ void BlockMetricsImpl::ConnectForkCheck(int64_t current, double avg)
 void BlockMetricsImpl::ConnectUpdateIndex(int64_t current, double avg)
 {
     this->setConnect("update-index", current, avg);
+}
+void BlockMetricsImpl::ConnectTotal(int64_t current, double avg)
+{
+    this->setConnect("connect-total", current, avg);
 }
 } // namespace metrics

--- a/src/metrics/block.h
+++ b/src/metrics/block.h
@@ -18,15 +18,15 @@ public:
     virtual void HeaderTime(int64_t amt) {}
     virtual void Reward(int64_t amt){};
     virtual void Fees(int64_t amt){};
-    virtual void Difficulty(double amt){};
     virtual void ValueOut(double amt){};
     virtual void TimeDeltaPrev(int64_t amt){};
 
     virtual void ConnectLoadBlockDisk(int64_t current, double avg){};
-    virtual void ConnectBlockTotal(int64_t current, double avg){};
+    virtual void ConnectBlock(int64_t current, double avg){};
     virtual void ConnectFlushView(int64_t current, double avg){};
     virtual void ConnectFlushDisk(int64_t current, double avg){};
-    virtual void ConnectUpdate(int64_t current, double avg){};
+    virtual void ConnectUpdateTip(int64_t current, double avg){};
+    virtual void ConnectTotal(int64_t current, double avg){};
 
     virtual void ConnectForkCheck(int64_t current, double avg){};
     virtual void ConnectUpdateIndex(int64_t current, double avg){};
@@ -54,6 +54,7 @@ protected:
     std::vector<std::string> _block_operations{
         "load",
         "connect-total",
+        "connect",
         "flush-view",
         "flush-disk",
         "update-tip",
@@ -84,12 +85,13 @@ public:
 
     // Timers for connecting a block
     void ConnectLoadBlockDisk(int64_t current, double avg) override;
-    void ConnectBlockTotal(int64_t current, double avg) override;
+    void ConnectBlock(int64_t current, double avg) override;
     void ConnectFlushView(int64_t current, double avg) override;
     void ConnectFlushDisk(int64_t current, double avg) override;
-    void ConnectUpdate(int64_t current, double avg) override;
+    void ConnectUpdateTip(int64_t current, double avg) override;
     void ConnectForkCheck(int64_t current, double avg) override;
     void ConnectUpdateIndex(int64_t current, double avg) override;
+    void ConnectTotal(int64_t current, double avg) override;
 };
 }
 #endif // BITCOIN_METRICS_BLOCK_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2673,7 +2673,7 @@ bool CChainState::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew
         assert(nBlocksTotal > 0);
         nCurrentTime = nTime3 - nTime2;
         nAvgTime = (double)nTimeConnectTotal / (double)nBlocksTotal;
-        blockMetrics.ConnectBlockTotal(nCurrentTime, nAvgTime);
+        blockMetrics.ConnectBlock(nCurrentTime, nAvgTime);
         LogPrint(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n", nCurrentTime * MILLI, nTimeConnectTotal * MICRO, nAvgTime * MILLI);
         bool flushed = view.Flush();
         assert(flushed);
@@ -2704,7 +2704,8 @@ bool CChainState::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew
     int64_t nTime6 = GetTimeMicros(); nTimePostConnect += nTime6 - nTime5; nTimeTotal += nTime6 - nTime1;
     nCurrentTime = nTime6 - nTime5;
     nAvgTime = (double)nTimePostConnect / (double)nBlocksTotal;
-    blockMetrics.ConnectUpdate(nCurrentTime, nAvgTime);
+    blockMetrics.ConnectUpdateTip(nCurrentTime, nAvgTime);
+    blockMetrics.ConnectTotal(nTime6 - nTime1, nTimeTotal / nBlocksTotal);
     LogPrint(BCLog::BENCH, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n", nCurrentTime * MILLI, nTimePostConnect * MICRO, nAvgTime * MILLI);
     LogPrint(BCLog::BENCH, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime1) * MILLI, nTimeTotal * MICRO, nTimeTotal * MILLI / nBlocksTotal);
     connectTrace.BlockConnected(pindexNew, std::move(pthisBlock));

--- a/test/functional/feature_metrics.py
+++ b/test/functional/feature_metrics.py
@@ -193,6 +193,7 @@ class MetricsTest(BitcoinTestFramework):
         block_connect = [
             "load",
             "connect-total",
+            "connect",
             "flush-view",
             "flush-disk",
             "update-tip",
@@ -214,6 +215,7 @@ class MetricsTest(BitcoinTestFramework):
             assert_equal(len(m.labels), 2)
             assert 'chain' in m.labels
             assert 'operation' in m.labels
+#            self.log.info('Checking label %s', m.labels['operation'])
             assert m.labels['operation'] in block_connect
             # ignore checking load operation value, too many false negatives
             if m.labels['operation'] != 'load':


### PR DESCRIPTION
to reflect `total` connect time

* Adding proper 'connect-total' label
* Adding 'connect' label to be time of connected block (but not total time)

